### PR TITLE
Add error handling for GET non 2xx responses.

### DIFF
--- a/client/components/error-display.jsx
+++ b/client/components/error-display.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function ErrorDisplay(props) {
+  let { status, message } = props;
+  status ??= '404';
+
+  return (
+    <div>
+      <div className="alert alert-error shadow-lg">
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 flex-shrink-0 stroke-current"
+            fill="none"
+            viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <span>
+            Error! {status} - {message}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/sar-renderer.jsx
+++ b/client/components/sar-renderer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as PIXI from 'pixi.js';
 import { Sprite2d } from 'pixi-projection';
 import convertRGBtoHex from '../lib/rgb-to-hex';
+import { toast } from 'react-toastify';
 
 function renderSar(sar) {
   const promise = new Promise((resolve, reject) => {
@@ -89,9 +90,15 @@ export default class SarRenderToPng extends React.Component {
   }
 
   componentDidMount() {
-    renderSar(this.props.sar).then(pngBase64 => {
-      this.setState({ imageSrc: pngBase64 });
-    });
+    toast.promise(
+      renderSar(this.props.sar).then(pngBase64 => {
+        this.setState({ imageSrc: pngBase64 });
+      }),
+      {
+        pending: 'Rendering Symbol Art...',
+        error: 'Error! Render has failed...'
+      }
+    );
   }
 
   componentWillUnmount() {
@@ -103,9 +110,15 @@ export default class SarRenderToPng extends React.Component {
       this.setState({ imageSrc: '' });
       PIXI.utils.destroyTextureCache();
 
-      renderSar(this.props.sar).then(pngBase64 => {
-        this.setState({ imageSrc: pngBase64 });
-      });
+      toast.promise(
+        renderSar(this.props.sar).then(pngBase64 => {
+          this.setState({ imageSrc: pngBase64 });
+        }),
+        {
+          pending: 'Loading Symbol Art...',
+          error: 'Error! Unable to load file'
+        }
+      );
     }
   }
 

--- a/client/components/symbol-art-single-post.jsx
+++ b/client/components/symbol-art-single-post.jsx
@@ -14,18 +14,6 @@ import Tag from './tag';
 export default function SinglePostSymbolArt(props) {
   const { playSound } = React.useContext(AppContext);
 
-  if (props.loading) {
-    return;
-  }
-
-  if (!props.symbolArt && !props.loading) {
-    return (
-      <div className="alert alert-error justify-center text-3xl font-bold">
-        <h2>Unable to find post with ID ({props.id})</h2>
-      </div>
-    );
-  }
-
   const {
     postId,
     title,

--- a/client/layout.jsx
+++ b/client/layout.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import Header from './components/header';
 import EditModal from './components/edit-modal';
 import AppContext from './lib/app-context';
@@ -8,6 +10,12 @@ export default class Layout extends React.Component {
   render() {
     return (
       <>
+        <ToastContainer
+          position="bottom-center"
+          autoClose={2500}
+          pauseOnHover={false}
+          pauseOnFocusLoss={false}
+        />
         <EditModal
           isOpen={this.context.editing}
           editing={this.context.editing}

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import ErrorDisplay from '../components/error-display';
 import SinglePostSymbolArt from '../components/symbol-art-single-post';
 import { apiViewPostFromId } from '../lib/endpoints';
 
@@ -8,22 +9,31 @@ export default function SinglePostPage(props) {
   const apiPath = apiViewPostFromId(id);
   const [symbolArt, setSymbolArt] = useState();
   const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState(null);
 
   useEffect(() => {
+    setErrorMessage(null);
     setLoading(true);
     fetch(apiPath)
-      .then(res => res.json())
       .then(res => {
-        if (Object.keys(res)[0] === 'error') {
-          setSymbolArt(null);
+        return Promise.all([res, res.json()]);
+      })
+      .then(tuple => {
+        const [res, resBody] = tuple;
+        if (!res.ok) {
+          setErrorMessage({
+            status: res.status,
+            message: resBody.error ? resBody.error : res.statusText
+          });
         } else {
-          setSymbolArt(res);
+          setSymbolArt(resBody);
         }
         setLoading(false);
       });
   }, [apiPath]);
 
-  return (
-    <SinglePostSymbolArt loading={loading} symbolArt={symbolArt} id={id} />
-  );
+  if (loading) return;
+  if (!loading && errorMessage) return <ErrorDisplay {...errorMessage} />;
+
+  return <SinglePostSymbolArt symbolArt={symbolArt} id={id} />;
 }

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -29,7 +29,8 @@ export default function SinglePostPage(props) {
           setSymbolArt(resBody);
         }
         setLoading(false);
-      });
+      })
+      .catch(err => console.error(err));
   }, [apiPath]);
 
   if (loading) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "final-project",
+  "name": "symbol-art-vault",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "final-project",
+      "name": "symbol-art-vault",
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.100.0",
@@ -28,6 +28,7 @@
         "react-dom": "^18.1.0",
         "react-lazy-load-image-component": "^1.5.4",
         "react-router-dom": "^6.3.0",
+        "react-toastify": "^9.0.4",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -5274,6 +5275,14 @@
       "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {
@@ -11888,6 +11897,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.4.tgz",
+      "integrity": "sha512-MYmJ1V5F6DEU+TFxBb+pGGsveFPt4tjr4yK+TopXkU3sXPD9F2tFhX+G2HBLZpqObT2O6Z9jbXSg3JpaxuWtWw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-pkg": {
@@ -18592,6 +18613,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -23498,6 +23524,14 @@
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.3.0"
+      }
+    },
+    "react-toastify": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.4.tgz",
+      "integrity": "sha512-MYmJ1V5F6DEU+TFxBb+pGGsveFPt4tjr4yK+TopXkU3sXPD9F2tFhX+G2HBLZpqObT2O6Z9jbXSg3JpaxuWtWw==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.1.0",
     "react-lazy-load-image-component": "^1.5.4",
     "react-router-dom": "^6.3.0",
+    "react-toastify": "^9.0.4",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/server/api/posts-download-id.js
+++ b/server/api/posts-download-id.js
@@ -24,7 +24,7 @@ module.exports = function postsDownloadId(req, res, next) {
   // prettier-ignore
   db.query(sql, [id])
     .then(reSQL => {
-      if (!reSQL.rows) {
+      if (!reSQL.rows[0]) {
         throw new ClientError(404, `unable to find entry with id: ${id}`);
       }
       const [{ fileObjectKey, title }] = reSQL.rows;

--- a/server/api/posts-view-id.js
+++ b/server/api/posts-view-id.js
@@ -3,12 +3,15 @@ const db = require('../lib/db');
 
 module.exports = function postsViewId(req, res, next) {
   const { id } = req.params;
+
   if (Number.isNaN(Number(id))) {
     throw new ClientError(400, 'please provide a valid post ID (number)');
   }
-  if (!(id >= 1) || !(id <= 2147483647)) {
+
+  if (!(id >= 1 && id <= 21474367)) {
     throw new ClientError(400, 'integer out of bounds');
   }
+
   const sql = `/* SQL */
     with "tag_arrays" as (
       select

--- a/server/index.js
+++ b/server/index.js
@@ -75,6 +75,7 @@ app.get('/posts/:id', (req, res, next) => {
   const { id } = req.params;
   if (!(id >= 1) || !(id <= 2147483647)) {
     res.render('index');
+    return;
   }
   const sql = `/* SQL */
     with "tag_arrays" as (


### PR DESCRIPTION
# resolves #50, resolves #29

## Changes 

- Added toasts for any promises being used within the Client.
- Added `ErrorDisplay` component to library to use when `GET` Fetch Requests fail.

## Preview

### Auth Page
![auth-page-toasts](https://user-images.githubusercontent.com/78003700/174356706-5fd15ded-4c01-4fb1-bae5-292dcc05c950.gif)

### Upload Page
![upload-page-toasts](https://user-images.githubusercontent.com/78003700/174356710-486be3ee-e43f-4340-b153-0bdbc04e7e6e.gif)
